### PR TITLE
feat/ 댓글 삭제 API 추가 (소프트 삭제, 스레드 비노출) 피드백 반영

### DIFF
--- a/src/main/java/com/mtcoding/minigram/posts/comments/Comment.java
+++ b/src/main/java/com/mtcoding/minigram/posts/comments/Comment.java
@@ -65,4 +65,19 @@ public class Comment {
         this.updatedAt = updatedAt;
         this.children = children;
     }
+
+    // --- 도메인 동작 추가 ---
+    public boolean isDeleted() {
+        return this.status == CommentStatus.DELETED;
+    }
+
+    /**
+     * 소프트 삭제 전용 메서드 (세터 없이 더티체킹 유도)
+     */
+    public void markDeleted() {
+        if (isDeleted()) return;
+        this.status = CommentStatus.DELETED;
+        // 필요하면 표시용 컨텐츠 변경도 여기서 함께
+        // this.content = "(삭제된 댓글)";
+    }
 }

--- a/src/main/java/com/mtcoding/minigram/posts/comments/Comment.java
+++ b/src/main/java/com/mtcoding/minigram/posts/comments/Comment.java
@@ -66,18 +66,12 @@ public class Comment {
         this.children = children;
     }
 
-    // --- 도메인 동작 추가 ---
     public boolean isDeleted() {
         return this.status == CommentStatus.DELETED;
     }
 
-    /**
-     * 소프트 삭제 전용 메서드 (세터 없이 더티체킹 유도)
-     */
     public void markDeleted() {
         if (isDeleted()) return;
         this.status = CommentStatus.DELETED;
-        // 필요하면 표시용 컨텐츠 변경도 여기서 함께
-        // this.content = "(삭제된 댓글)";
     }
 }

--- a/src/main/java/com/mtcoding/minigram/posts/comments/CommentRepository.java
+++ b/src/main/java/com/mtcoding/minigram/posts/comments/CommentRepository.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Repository
@@ -15,24 +16,13 @@ public class CommentRepository {
     // 게시글별 댓글 수
     public long countByPostId(Integer postId) {
         return em.createQuery(
-                        "select count(c) from Comment c where c.post.id = :postId",
+                        "select count(c) from Comment c " +
+                                "where c.post.id = :postId and c.status = :active",
                         Long.class
                 )
                 .setParameter("postId", postId)
+                .setParameter("active", CommentStatus.ACTIVE)
                 .getSingleResult();
-    }
-
-    // 게시글의 전체 댓글 (유저 join fetch)
-    public List<Comment> findAllByPostId(Integer postId) {
-        return em.createQuery(
-                        "select c from Comment c " +
-                                "join fetch c.user " +
-                                "where c.post.id = :postId " +
-                                "order by c.id desc",
-                        Comment.class
-                )
-                .setParameter("postId", postId)
-                .getResultList();
     }
 
     // 부모 댓글만 (최상위) - 오래된 순
@@ -43,11 +33,13 @@ public class CommentRepository {
                                 join fetch c.user
                                 where c.post.id = :postId
                                   and c.parent is null
+                                  and c.status = :active
                                 order by c.createdAt asc, c.id asc
                                 """,
                         Comment.class
                 )
                 .setParameter("postId", postId)
+                .setParameter("active", CommentStatus.ACTIVE)
                 .getResultList();
     }
 
@@ -59,11 +51,31 @@ public class CommentRepository {
                                 select c from Comment c
                                 join fetch c.user
                                 where c.parent.id in :pids
+                                  and c.status = :active
                                 order by c.createdAt asc, c.id asc
                                 """,
                         Comment.class
                 )
                 .setParameter("pids", parentIds)
+                .setParameter("active", CommentStatus.ACTIVE)
                 .getResultList();
+    }
+
+    // 삭제 권한 판단용 단건 조회 (댓글 + 작성자 + 게시글 + 게시글 작성자)
+    public Optional<Comment> findWithPostAndUsersById(Integer commentId) {
+        return em.createQuery(
+                        """
+                                select c
+                                from Comment c
+                                join fetch c.user         
+                                join fetch c.post p
+                                join fetch p.user         
+                                where c.id = :id
+                                """,
+                        Comment.class
+                )
+                .setParameter("id", commentId)
+                .getResultStream()
+                .findFirst();
     }
 }

--- a/src/main/java/com/mtcoding/minigram/posts/comments/CommentResponse.java
+++ b/src/main/java/com/mtcoding/minigram/posts/comments/CommentResponse.java
@@ -84,4 +84,12 @@ public class CommentResponse {
             );
         }
     }
+
+    @Data
+    @AllArgsConstructor
+    public static class DeleteDTO {
+        private Integer commentId;
+        private String message;
+    }
 }
+

--- a/src/main/java/com/mtcoding/minigram/posts/comments/CommentService.java
+++ b/src/main/java/com/mtcoding/minigram/posts/comments/CommentService.java
@@ -91,10 +91,9 @@ public class CommentService {
                 .orElseThrow(() -> new ExceptionApi404("댓글이 존재하지 않습니다."));
 
         boolean isAuthor = comment.getUser().getId().equals(requesterId);
-        boolean isPostAuthor = comment.getPost().getUser().getId().equals(requesterId);
         boolean isAdmin = roles != null && roles.contains("ADMIN");
 
-        if (!(isAuthor || isPostAuthor || isAdmin)) {
+        if (!(isAuthor || isAdmin)) {
             throw new ExceptionApi403("삭제 권한이 없습니다.");
         }
 
@@ -103,12 +102,7 @@ public class CommentService {
         }
 
         comment.markDeleted(); // 엔티티 도메인 메서드
-        String msg = isAdmin
-                ? "관리자 권한으로 댓글을 삭제했습니다."
-                : isPostAuthor
-                ? "게시글 작성자 권한으로 댓글을 삭제했습니다."
-                : "댓글을 삭제했습니다.";
-
+        String msg = isAdmin ? "관리자 권한으로 댓글을 삭제했습니다." : "댓글을 삭제했습니다.";
         return new CommentResponse.DeleteDTO(commentId, msg);
     }
 }

--- a/src/main/java/com/mtcoding/minigram/posts/comments/CommentService.java
+++ b/src/main/java/com/mtcoding/minigram/posts/comments/CommentService.java
@@ -102,7 +102,7 @@ public class CommentService {
             return new CommentResponse.DeleteDTO(commentId, "이미 삭제된 댓글입니다.");
         }
 
-        comment.markDeleted(); // ← 엔티티 도메인 메서드 (세터 없이 더티체킹)
+        comment.markDeleted(); // 엔티티 도메인 메서드
         String msg = isAdmin
                 ? "관리자 권한으로 댓글을 삭제했습니다."
                 : isPostAuthor

--- a/src/main/java/com/mtcoding/minigram/posts/comments/CommentsController.java
+++ b/src/main/java/com/mtcoding/minigram/posts/comments/CommentsController.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +20,12 @@ public class CommentsController {
     @GetMapping("s/api/posts/{postId}/comments")
     public ResponseEntity<?> findAllByPostId(@PathVariable Integer postId, @AuthenticationPrincipal User user) {
         CommentResponse.ListDTO respDTO = commentService.findAllByPostId(postId, user.getId());
+        return Resp.ok(respDTO);
+    }
+
+    @DeleteMapping("/s/api/comments/{commentId}")
+    public ResponseEntity<?> delete(@PathVariable Integer commentId, @AuthenticationPrincipal User user) {
+        CommentResponse.DeleteDTO respDTO = commentService.delete(commentId, user.getId(), user.getRoles());
         return Resp.ok(respDTO);
     }
 }

--- a/src/main/resources/db/01-users.sql
+++ b/src/main/resources/db/01-users.sql
@@ -1,7 +1,7 @@
 -- 01-users.sql
 
 INSERT INTO users_tb (email, username, password, roles, name, gender, birthdate, profile_image_url, bio, created_at,
-                      update_at)
+                      updated_at)
 VALUES
 -- 관리자 계정
 ('admin@minigram.com', 'minigram',

--- a/src/test/java/com/mtcoding/minigram/integre/CommentsControllerTest.java
+++ b/src/test/java/com/mtcoding/minigram/integre/CommentsControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.matchesPattern;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -79,4 +80,24 @@ public class CommentsControllerTest extends MyRestDoc {
 
         actions.andDo(document);
     }
+
+    @Test
+    @DisplayName("댓글 삭제 - 작성자 본인 → 204 & 목록에서 제외")
+    void delete_byAuthor_200_with_message() throws Exception {
+        int commentId = 1; // ssar(2번)의 댓글
+
+        ResultActions actions = mvc.perform(delete("/s/api/comments/{commentId}", commentId)
+                .header("Authorization", "Bearer " + accessToken));
+
+        String responseBody = actions.andReturn().getResponse().getContentAsString();
+        System.out.println(responseBody);
+
+        actions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.msg").value("성공"))
+                .andExpect(jsonPath("$.body.commentId").value(commentId))
+                .andExpect(jsonPath("$.body.message").value("댓글을 삭제했습니다."));
+    }
+
+
 }

--- a/src/test/java/com/mtcoding/minigram/integre/CommentsControllerTest.java
+++ b/src/test/java/com/mtcoding/minigram/integre/CommentsControllerTest.java
@@ -82,7 +82,7 @@ public class CommentsControllerTest extends MyRestDoc {
     }
 
     @Test
-    @DisplayName("댓글 삭제 - 작성자 본인 → 204 & 목록에서 제외")
+    @DisplayName("댓글 삭제")
     void delete_test() throws Exception {
         int commentId = 1; // ssar(2번)의 댓글
 

--- a/src/test/java/com/mtcoding/minigram/integre/CommentsControllerTest.java
+++ b/src/test/java/com/mtcoding/minigram/integre/CommentsControllerTest.java
@@ -83,11 +83,11 @@ public class CommentsControllerTest extends MyRestDoc {
 
     @Test
     @DisplayName("댓글 삭제 - 작성자 본인 → 204 & 목록에서 제외")
-    void delete_byAuthor_200_with_message() throws Exception {
+    void delete_test() throws Exception {
         int commentId = 1; // ssar(2번)의 댓글
 
         ResultActions actions = mvc.perform(delete("/s/api/comments/{commentId}", commentId)
-                .header("Authorization", "Bearer " + accessToken));
+                .header("Authorization", accessToken));
 
         String responseBody = actions.andReturn().getResponse().getContentAsString();
         System.out.println(responseBody);
@@ -96,7 +96,8 @@ public class CommentsControllerTest extends MyRestDoc {
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.msg").value("성공"))
                 .andExpect(jsonPath("$.body.commentId").value(commentId))
-                .andExpect(jsonPath("$.body.message").value("댓글을 삭제했습니다."));
+                .andExpect(jsonPath("$.body.message").value("댓글을 삭제했습니다."))
+                .andDo(document);
     }
 
 


### PR DESCRIPTION
요약

댓글 삭제 엔드포인트 추가: DELETE /s/api/comments/{commentId}

소프트 삭제(status=DELETED) 적용, 멱등성 보장

목록 조회 시 삭제된 부모 스레드 전체 비노출 (인스타 동작과 동일)

컨벤션 준수: Controller/Service 메서드명 delete

비즈니스 규칙

권한: 작성자 본인만 삭제 가능 (관리자 권한은 후속 PR에서 논의)

소프트 삭제: comments_tb.status = 'DELETED'

멱등: 이미 삭제된 댓글에 대해 다시 삭제 호출 시에도 200/성공 반환

표시 정책(인스타 스타일):

부모 댓글이 삭제되면 해당 스레드(부모+자식) 비노출

대댓글 단독 삭제 시 해당 대댓글만 비노출

구현은 “조회 시 필터”로 처리 (자식은 DB에 남아도 부모가 ACTIVE일 때만 children로 묶임)

테스트

<img width="997" height="102" alt="image" src="https://github.com/user-attachments/assets/b25e48fa-f0ce-4f12-81ca-4edfbd60c0ef" />

<img width="256" height="144" alt="image" src="https://github.com/user-attachments/assets/65bcf1fb-129f-47ed-bcef-2d77e15a7d90" />

포스트맨 테스트


삭제하기전 댓글
<img width="730" height="878" alt="image" src="https://github.com/user-attachments/assets/2e59edae-dfc6-46e3-96cb-ede3ed0ffe9e" />


댓글 삭제요청
<img width="376" height="509" alt="image" src="https://github.com/user-attachments/assets/5d34801b-8c31-42e1-bfea-a111f3f8cdd7" />

댓글 삭제완료
<img width="674" height="862" alt="image" src="https://github.com/user-attachments/assets/9d365890-3adb-43cf-8ef2-6b816e2e4af3" />
