### PR TITLE
feat / 관리자 광고 등록 API 구현

### DIFF
--- a/src/main/java/com/mtcoding/minigram/advertisements/Advertisement.java
+++ b/src/main/java/com/mtcoding/minigram/advertisements/Advertisement.java
@@ -64,11 +64,17 @@ public class Advertisement {
         this.updatedAt = updatedAt;
     }
 
-    public static Advertisement create(Post post, User admin, LocalDateTime startAt, LocalDateTime endAt, AdvertisementStatus status) {
 
-        var now = LocalDateTime.now();
+    // @MapsId로 INSERT가 flush까지 지연될 수 있어 save 직후에도 타임스탬프가 null 되지 않도록 라이프사이클에서 직접 세팅.
+    @PrePersist
+    void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
 
-        return new Advertisement(null, post, admin, (status == null ? AdvertisementStatus.ACTIVE : status), startAt, endAt, now, now);
-
+    @PreUpdate
+    void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/mtcoding/minigram/advertisements/Advertisement.java
+++ b/src/main/java/com/mtcoding/minigram/advertisements/Advertisement.java
@@ -63,4 +63,12 @@ public class Advertisement {
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
+
+    public static Advertisement create(Post post, User admin, LocalDateTime startAt, LocalDateTime endAt, AdvertisementStatus status) {
+
+        var now = LocalDateTime.now();
+
+        return new Advertisement(null, post, admin, (status == null ? AdvertisementStatus.ACTIVE : status), startAt, endAt, now, now);
+
+    }
 }

--- a/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementRepository.java
+++ b/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementRepository.java
@@ -8,4 +8,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class AdvertisementRepository {
     private final EntityManager em;
+
+    public Advertisement save(Advertisement ad) {
+        em.persist(ad);
+        return ad;
+    }
 }

--- a/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementRequest.java
+++ b/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementRequest.java
@@ -1,4 +1,20 @@
 package com.mtcoding.minigram.advertisements;
 
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
 public class AdvertisementRequest {
+
+    @Data
+    @NoArgsConstructor
+    public static class CreateDTO {   // JSON 전용 (파일 업로드 없음)
+        private String content;       // 캡션
+        private List<String> imageUrls; // Presign 업로드 후 최종 URL들
+        private LocalDateTime startAt; // 광고 시작일
+        private LocalDateTime endAt; // 광고 종료일
+    }
+
 }

--- a/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementResponse.java
+++ b/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementResponse.java
@@ -9,7 +9,7 @@ public class AdvertisementResponse {
 
     @Data
     @AllArgsConstructor
-    public static class SavedDTO {
+    public static class CreateDTO {
         private final Integer adId;
         private final Integer postId;
         private final Integer userId;
@@ -19,7 +19,7 @@ public class AdvertisementResponse {
         private final LocalDateTime createdAt;
         private final LocalDateTime updatedAt;
 
-        public static SavedDTO from(Advertisement ad) {
+        public static CreateDTO from(Advertisement ad) {
             return new SavedDTO(
                     ad.getPostId(),
                     ad.getPost().getId(),

--- a/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementResponse.java
+++ b/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementResponse.java
@@ -1,4 +1,35 @@
 package com.mtcoding.minigram.advertisements;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
 public class AdvertisementResponse {
+
+    @Data
+    @AllArgsConstructor
+    public static class DetailDTO {
+        private final Integer adId;
+        private final Integer postId;
+        private final Integer userId;
+        private final AdvertisementStatus status;
+        private final LocalDateTime startAt;
+        private final LocalDateTime endAt;
+        private final LocalDateTime createdAt;
+        private final LocalDateTime updatedAt;
+
+        public static DetailDTO from(Advertisement ad) {
+            return new DetailDTO(
+                    ad.getPostId(),
+                    ad.getPost().getId(),
+                    ad.getUser().getId(),
+                    ad.getStatus(),
+                    ad.getStartAt(),
+                    ad.getEndAt(),
+                    ad.getCreatedAt(),
+                    ad.getUpdatedAt()
+            );
+        }
+    }
 }

--- a/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementResponse.java
+++ b/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementResponse.java
@@ -9,7 +9,7 @@ public class AdvertisementResponse {
 
     @Data
     @AllArgsConstructor
-    public static class DetailDTO {
+    public static class SavedDTO {
         private final Integer adId;
         private final Integer postId;
         private final Integer userId;
@@ -19,8 +19,8 @@ public class AdvertisementResponse {
         private final LocalDateTime createdAt;
         private final LocalDateTime updatedAt;
 
-        public static DetailDTO from(Advertisement ad) {
-            return new DetailDTO(
+        public static SavedDTO from(Advertisement ad) {
+            return new SavedDTO(
                     ad.getPostId(),
                     ad.getPost().getId(),
                     ad.getUser().getId(),

--- a/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementService.java
+++ b/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementService.java
@@ -1,8 +1,23 @@
 package com.mtcoding.minigram.advertisements;
 
+import com.mtcoding.minigram._core.error.ex.ExceptionApi400;
+import com.mtcoding.minigram._core.error.ex.ExceptionApi403;
+import com.mtcoding.minigram._core.error.ex.ExceptionApi404;
+import com.mtcoding.minigram.posts.Post;
+import com.mtcoding.minigram.posts.PostRepository;
+import com.mtcoding.minigram.posts.PostStatus;
+import com.mtcoding.minigram.posts.images.PostImage;
+import com.mtcoding.minigram.posts.images.PostImageRepository;
+import com.mtcoding.minigram.users.User;
+import com.mtcoding.minigram.users.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 // @Slf4j
 // - Lombok이 자동으로 Logger 필드를 추가해주는 어노테이션
@@ -12,4 +27,66 @@ import org.springframework.stereotype.Service;
 @Service
 public class AdvertisementService {
     private final AdvertisementRepository advertisementRepository;
+    private final PostRepository postRepository;
+    private final PostImageRepository postImageRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public AdvertisementResponse.DetailDTO create(AdvertisementRequest.CreateDTO req, Integer adminUserId) {
+
+        if (req.getStartAt().isAfter(req.getEndAt())) {
+            throw new ExceptionApi400("startAt은 endAt보다 이후일 수 없습니다.");
+        }
+
+        // 1) 관리자 로딩 + 권한 체크
+        User admin = userRepository.findById(adminUserId)
+                .orElseThrow(() -> new ExceptionApi404("사용자를 찾을 수 없습니다."));
+        if (!admin.getRoles().contains("ADMIN")) {
+            throw new ExceptionApi403("관리자 권한이 필요합니다.");
+        }
+
+        // 2) 이미지 URL 정제(포스트 서비스와 동일한 패턴)
+        List<String> cleanedUrls = Optional.ofNullable(req.getImageUrls())
+                .orElse(List.of())
+                .stream()
+                .map(s -> s == null ? "" : s.trim())
+                .filter(s -> !s.isBlank())
+                .distinct()
+                .toList();
+
+        if (cleanedUrls.isEmpty()) throw new ExceptionApi400("이미지 최소 1장은 필요합니다.");
+        if (cleanedUrls.size() > 10) throw new ExceptionApi400("이미지는 최대 10장까지 가능합니다.");
+
+        // 3) Post 저장 (상태 NOT NULL 주의)
+        Post post = Post.builder()
+                .user(admin)
+                .content(req.getContent())
+                .status(PostStatus.ACTIVE)
+                .build();
+        postRepository.save(post);
+
+        // 4) PostImage 저장 (정렬 필요 없으면 생략 / 필요하면 sort 컬럼 사용)
+        List<PostImage> savedImages = new ArrayList<>(cleanedUrls.size());
+        for (String url : cleanedUrls) {
+            PostImage pi = PostImage.builder()
+                    .post(post)
+                    .url(url)
+                    .build();
+            postImageRepository.save(pi);
+            savedImages.add(pi);
+        }
+
+        // 5) Advertisement 저장 (@MapsId → PK = post_id)
+        Advertisement ad = Advertisement.builder()
+                .post(post)
+                .user(admin)
+                .status(AdvertisementStatus.ACTIVE)
+                .startAt(req.getStartAt())
+                .endAt(req.getEndAt())
+                .build();
+        advertisementRepository.save(ad);
+
+        // 6) 응답 (공유 PK라 adId == postId)
+        return AdvertisementResponse.DetailDTO.from(ad);
+    }
 }

--- a/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementService.java
+++ b/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementService.java
@@ -32,7 +32,7 @@ public class AdvertisementService {
     private final UserRepository userRepository;
 
     @Transactional
-    public AdvertisementResponse.DetailDTO create(AdvertisementRequest.CreateDTO req, Integer adminUserId) {
+    public AdvertisementResponse.SavedDTO create(AdvertisementRequest.CreateDTO req, Integer adminUserId) {
 
         if (req.getStartAt().isAfter(req.getEndAt())) {
             throw new ExceptionApi400("startAt은 endAt보다 이후일 수 없습니다.");
@@ -87,6 +87,6 @@ public class AdvertisementService {
         advertisementRepository.save(ad);
 
         // 6) 응답 (공유 PK라 adId == postId)
-        return AdvertisementResponse.DetailDTO.from(ad);
+        return AdvertisementResponse.SavedDTO.from(ad);
     }
 }

--- a/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementsController.java
+++ b/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementsController.java
@@ -1,12 +1,27 @@
 package com.mtcoding.minigram.advertisements;
 
+import com.mtcoding.minigram._core.util.Resp;
+import com.mtcoding.minigram.users.User;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
+@RequestMapping("/s/api/admin/advertisements")
 public class AdvertisementsController {
     private final AdvertisementService advertisementService;
     private final HttpSession session;
+
+    @PostMapping()
+    public ResponseEntity<?> create(@AuthenticationPrincipal User user, @RequestBody AdvertisementRequest.CreateDTO reqDTO) {
+        AdvertisementResponse.DetailDTO respDTO = advertisementService.create(reqDTO, user.getId());
+        return Resp.ok(respDTO); // DetailDTO 반환
+    }
+
 }

--- a/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementsController.java
+++ b/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementsController.java
@@ -20,8 +20,9 @@ public class AdvertisementsController {
 
     @PostMapping()
     public ResponseEntity<?> create(@AuthenticationPrincipal User user, @RequestBody AdvertisementRequest.CreateDTO reqDTO) {
-        AdvertisementResponse.DetailDTO respDTO = advertisementService.create(reqDTO, user.getId());
+        AdvertisementResponse.SavedDTO respDTO = advertisementService.create(reqDTO, user.getId());
         return Resp.ok(respDTO); // DetailDTO 반환
     }
+
 
 }

--- a/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementsController.java
+++ b/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementsController.java
@@ -20,7 +20,7 @@ public class AdvertisementsController {
 
     @PostMapping()
     public ResponseEntity<?> create(@AuthenticationPrincipal User user, @RequestBody AdvertisementRequest.CreateDTO reqDTO) {
-        AdvertisementResponse.SavedDTO respDTO = advertisementService.create(reqDTO, user.getId());
+        AdvertisementResponse.CreateDTO respDTO = advertisementService.create(reqDTO, user.getId());
         return Resp.ok(respDTO); // DetailDTO 반환
     }
 

--- a/src/main/resources/db/01-users.sql
+++ b/src/main/resources/db/01-users.sql
@@ -1,7 +1,7 @@
 -- 01-users.sql
 
 INSERT INTO users_tb (email, username, password, roles, name, gender, birthdate, profile_image_url, bio, created_at,
-                      update_at)
+                      updated_at)
 VALUES
 -- 관리자 계정
 ('admin@minigram.com', 'minigram',

--- a/src/test/java/com/mtcoding/minigram/integre/AdvertisementsControllerTest.java
+++ b/src/test/java/com/mtcoding/minigram/integre/AdvertisementsControllerTest.java
@@ -1,0 +1,85 @@
+package com.mtcoding.minigram.integre;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mtcoding.minigram.MyRestDoc;
+import com.mtcoding.minigram._core.util.JwtUtil;
+import com.mtcoding.minigram.users.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+public class AdvertisementsControllerTest extends MyRestDoc {
+
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper om;
+
+    private String adminToken;
+
+    @BeforeEach
+    public void setUp() {
+        // 테스트 시작 전에 실행할 코드
+        User user = User.builder().id(1).username("minigram").roles("ADMIN").build();
+        adminToken = JwtUtil.create(user);
+    }
+
+
+    @Test
+    @DisplayName("광고 생성(신규 게시글 포함) - OK")
+    void create_withPost_ok() throws Exception {
+        // given
+        String body = """
+                {
+                  "content": "📢 [광고] 가을 세일 최대 50%!",
+                  "imageUrls": [
+                    "https://picsum.photos/seed/ad_new_a/800/600",
+                    "https://picsum.photos/seed/ad_new_b/800/600"
+                  ],
+                  "startAt": "2025-09-11T00:00:00",
+                  "endAt":   "2025-09-18T23:59:59"
+                }
+                """;
+
+        // when
+        ResultActions actions = mvc.perform(
+                post("/s/api/admin/advertisements")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body)
+        );
+
+        String responseBody = actions.andReturn().getResponse().getContentAsString();
+        System.out.println(responseBody);
+
+        // then (신규 postId/adId는 고정값이 아니므로 존재/양수만 체크)
+        actions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.msg").value("성공"))
+                .andExpect(jsonPath("$.body.adId").exists())
+                .andExpect(jsonPath("$.body.postId", greaterThan(0)))
+                .andExpect(jsonPath("$.body.userId").value(1))
+                .andExpect(jsonPath("$.body.status").value("ACTIVE"))
+                .andExpect(jsonPath("$.body.createdAt", matchesPattern("\\d{4}-\\d{2}-\\d{2}T.*")))
+                .andExpect(jsonPath("$.body.updatedAt", matchesPattern("\\d{4}-\\d{2}-\\d{2}T.*")));
+    }
+
+}

--- a/src/test/java/com/mtcoding/minigram/integre/AdvertisementsControllerTest.java
+++ b/src/test/java/com/mtcoding/minigram/integre/AdvertisementsControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.hamcrest.Matchers.greaterThan;
@@ -79,7 +80,8 @@ public class AdvertisementsControllerTest extends MyRestDoc {
                 .andExpect(jsonPath("$.body.userId").value(1))
                 .andExpect(jsonPath("$.body.status").value("ACTIVE"))
                 .andExpect(jsonPath("$.body.createdAt", matchesPattern("\\d{4}-\\d{2}-\\d{2}T.*")))
-                .andExpect(jsonPath("$.body.updatedAt", matchesPattern("\\d{4}-\\d{2}-\\d{2}T.*")));
+                .andExpect(jsonPath("$.body.updatedAt", matchesPattern("\\d{4}-\\d{2}-\\d{2}T.*")))
+                .andDo(MockMvcResultHandlers.print()).andDo(document);
     }
 
 }


### PR DESCRIPTION

요약

관리자가 광고를 등록하는 API를 추가했습니다.

신규 게시글 작성 + 광고 동시 생성(@MapsId)


테스트

<img width="1663" height="131" alt="image" src="https://github.com/user-attachments/assets/b57ea6ec-40c8-4f8b-8246-c073bee2a753" />

<img width="274" height="228" alt="image" src="https://github.com/user-attachments/assets/0bfeb23c-fae0-4e39-84b9-0c1764c50d0d" />

포스트맨 테스트

<img width="509" height="706" alt="image" src="https://github.com/user-attachments/assets/dae7c51a-51fc-4cf5-ac1e-defbb2ee90d4" />

<img width="629" height="852" alt="image" src="https://github.com/user-attachments/assets/7c3f748d-1ec1-4231-9778-033565a92b58" />


