### PR TITLE
Fix / 상세보기에 광고 여부(isAd) 추가 + 광고 컨텍스트 팔로우 미노출

### DIFF
--- a/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementRepository.java
+++ b/src/main/java/com/mtcoding/minigram/advertisements/AdvertisementRepository.java
@@ -4,8 +4,29 @@ import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @Repository
 public class AdvertisementRepository {
     private final EntityManager em;
+
+    public Optional<Advertisement> findActiveNowByPostId(Integer postId) {
+        LocalDateTime now = LocalDateTime.now();
+        List<Advertisement> list = em.createQuery(
+                        "select a from Advertisement a " +
+                                "where a.post.id = :postId " +
+                                "  and a.status = :status " +
+                                "  and :now between a.startAt and a.endAt",
+                        Advertisement.class)
+                .setParameter("postId", postId)
+                .setParameter("status", AdvertisementStatus.ACTIVE)
+                .setParameter("now", now)
+                .setMaxResults(1)
+                .getResultList();
+
+        return list.isEmpty() ? Optional.empty() : Optional.of(list.get(0));
+    }
 }

--- a/src/main/java/com/mtcoding/minigram/posts/PostResponse.java
+++ b/src/main/java/com/mtcoding/minigram/posts/PostResponse.java
@@ -21,13 +21,14 @@ public class PostResponse {
         private Integer commentCount;
         private LocalDateTime postedAt;
         private Boolean isReported;
+        private Boolean isAd;
 
         public DetailDTO(Post post,
                          List<PostImage> images,
                          int likeCount, boolean isLiked,
                          int commentCount,
                          boolean isOwner, boolean isFollowing,
-                         boolean isReported) {
+                         boolean isReported, boolean isAd) {
 
             this.postId = post.getId();
             this.content = post.getContent();
@@ -38,7 +39,7 @@ public class PostResponse {
                     post.getUser().getId(),
                     post.getUser().getUsername(),
                     post.getUser().getProfileImageUrl(),
-                    isFollowing,
+                    isAd ? null : isFollowing,
                     isOwner
             );
 
@@ -51,6 +52,7 @@ public class PostResponse {
             this.likes = new LikesDTO(likeCount, isLiked);
             this.commentCount = commentCount;
             this.isReported = isReported;
+            this.isAd = isAd;
         }
     }
 
@@ -162,7 +164,7 @@ public class PostResponse {
     }
 
     @Data
-    public static class ItemDTO{
+    public static class ItemDTO {
         private Integer postId;
         private String content;
         private Boolean isLiked;
@@ -174,7 +176,7 @@ public class PostResponse {
 
 
         @Data
-        public class UserDTO{
+        public class UserDTO {
             private Integer userId;
             private String username;
             private String profileImageUrl;
@@ -187,7 +189,7 @@ public class PostResponse {
         }
 
         @Data
-        public class PostImageDTO{
+        public class PostImageDTO {
             private Integer postImageId;
             private String url;
 

--- a/src/main/java/com/mtcoding/minigram/posts/PostResponse.java
+++ b/src/main/java/com/mtcoding/minigram/posts/PostResponse.java
@@ -1,5 +1,6 @@
 package com.mtcoding.minigram.posts;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.mtcoding.minigram.posts.images.PostImage;
 import com.mtcoding.minigram.users.User;
 import lombok.AllArgsConstructor;
@@ -99,6 +100,7 @@ public class PostResponse {
         private String username;
         private String profileImageUrl;
 
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         private Boolean isFollowing;
 
         private Boolean isOwner;

--- a/src/main/resources/db/01-users.sql
+++ b/src/main/resources/db/01-users.sql
@@ -1,7 +1,7 @@
 -- 01-users.sql
 
 INSERT INTO users_tb (email, username, password, roles, name, gender, birthdate, profile_image_url, bio, created_at,
-                      update_at)
+                      updated_at)
 VALUES
 -- 관리자 계정
 ('admin@minigram.com', 'minigram',

--- a/src/main/resources/db/10-advertisements.sql
+++ b/src/main/resources/db/10-advertisements.sql
@@ -3,6 +3,7 @@
 
 INSERT INTO advertisements_tb (post_id, user_id, status, start_at, end_at, created_at, updated_at)
 VALUES
+    
 -- 광고 1: 특별 혜택 캠페인 (1주일간 진행)
 (1, 1, 'ACTIVE', NOW(), DATEADD('DAY', 7, NOW()), now(), now()),
 

--- a/src/test/java/com/mtcoding/minigram/integre/PostsControllerTest.java
+++ b/src/test/java/com/mtcoding/minigram/integre/PostsControllerTest.java
@@ -48,7 +48,7 @@ public class PostsControllerTest extends MyRestDoc {
     }
 
     @Test
-    @DisplayName("게시글 단건 조회 - OK")
+    @DisplayName("게시글 단건 조회 - OK (일반 게시글)")
     void find_test() throws Exception {
 
         int postId = 18;
@@ -83,11 +83,51 @@ public class PostsControllerTest extends MyRestDoc {
                 .andExpect(jsonPath("$.body.likes.isLiked").value(true))
                 .andExpect(jsonPath("$.body.commentCount").value(15))
                 .andExpect(jsonPath("$.body.postedAt").isString())
-                .andExpect(jsonPath("$.body.isReported").value(true));
+                .andExpect(jsonPath("$.body.isReported").value(true))
+                .andExpect(jsonPath("$.body.isAd").value(false));
 
 
         actions.andDo(document);
     }
+
+    @Test
+    @DisplayName("게시글 단건 조회 - OK (광고 게시글: isFollowing 미노출)")
+    void find_ad_post_test() throws Exception {
+        // 시드에서 postId=1을 광고로 설정해둔다 (ACTIVE + 기간 유효)
+        int postId = 1;
+
+        ResultActions actions = mvc.perform(
+                get("/s/api/posts/{postId}", postId)
+                        .header("Authorization", accessToken)
+                        .accept(MediaType.APPLICATION_JSON_VALUE)
+        );
+
+        actions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.msg").value("성공"))
+                .andExpect(jsonPath("$.body.postId").value(1))
+                .andExpect(jsonPath("$.body.author.isFollowing").doesNotExist())
+
+                .andExpect(jsonPath("$.body.author.userId").value(1))
+                .andExpect(jsonPath("$.body.author.username").value("minigram"))
+                .andExpect(jsonPath("$.body.author.profileImageUrl",
+                        anyOf(nullValue(), matchesPattern("^https?://.+"))))
+                .andExpect(jsonPath("$.body.author.isOwner").value(false))
+                .andExpect(jsonPath("$.body.images", hasSize(2)))
+                .andExpect(jsonPath("$.body.images[0].id").isNumber())
+                .andExpect(jsonPath("$.body.images[0].url").isString())
+                .andExpect(jsonPath("$.body.content",
+                        containsString("[광고]")))
+                .andExpect(jsonPath("$.body.likes.count").value(3))
+                .andExpect(jsonPath("$.body.likes.isLiked").value(true))
+                .andExpect(jsonPath("$.body.commentCount").value(5))
+                .andExpect(jsonPath("$.body.postedAt",
+                        matchesPattern("\\d{4}-\\d{2}-\\d{2}T.*")))
+                .andExpect(jsonPath("$.body.isReported").value(false))
+                .andExpect(jsonPath("$.body.isAd").value(true));  // ← 광고
+        actions.andDo(document);
+    }
+
 
     @Test
     @DisplayName("게시글 작성 - OK (JSON)")

--- a/src/test/java/com/mtcoding/minigram/integre/PostsControllerTest.java
+++ b/src/test/java/com/mtcoding/minigram/integre/PostsControllerTest.java
@@ -59,8 +59,8 @@ public class PostsControllerTest extends MyRestDoc {
                         .accept(MediaType.APPLICATION_JSON_VALUE)
         );
 
-        String responseBody = actions.andReturn().getResponse().getContentAsString();
-        System.out.println(responseBody);
+//        String responseBody = actions.andReturn().getResponse().getContentAsString();
+//        System.out.println(responseBody);
 
         actions.andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
@@ -101,6 +101,9 @@ public class PostsControllerTest extends MyRestDoc {
                         .header("Authorization", accessToken)
                         .accept(MediaType.APPLICATION_JSON_VALUE)
         );
+
+        String responseBody = actions.andReturn().getResponse().getContentAsString();
+        System.out.println(responseBody);
 
         actions.andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
@@ -255,8 +258,8 @@ public class PostsControllerTest extends MyRestDoc {
         );
 
         // eye
-        String responseBody = actions.andReturn().getResponse().getContentAsString();
-        System.out.println(responseBody);
+//        String responseBody = actions.andReturn().getResponse().getContentAsString();
+//        System.out.println(responseBody);
 
         // then
         actions.andExpect(MockMvcResultMatchers.jsonPath("$.status").value(200));


### PR DESCRIPTION
요약

게시글 상세 응답에 **광고 여부 isAd**를 추가.

광고 게시글일 때 author.isFollowing 필드를 미노출(omit) 하도록 변경.

테스트

일반 상세

<img width="372" height="575" alt="image" src="https://github.com/user-attachments/assets/cdd75738-9146-4b17-844f-ad000a112e30" />

<img width="550" height="674" alt="image" src="https://github.com/user-attachments/assets/a3d75f8f-2c4d-4426-b358-467821ddd8ff" />

<img width="583" height="498" alt="image" src="https://github.com/user-attachments/assets/e256a243-3f34-4ba9-be33-2e9fba9992a5" />

광고 상세

<img width="381" height="470" alt="image" src="https://github.com/user-attachments/assets/5f8117dd-9a7d-4e07-9f61-a18b56166ad3" />

<img width="540" height="760" alt="image" src="https://github.com/user-attachments/assets/be405066-5555-4034-a086-21972bfe8a03" />


